### PR TITLE
minjs filter fails with files with "min" in the name, like admin.js

### DIFF
--- a/lib/filter.js
+++ b/lib/filter.js
@@ -12,6 +12,7 @@
  module.exports.compileFilters = function(options){
    var results = [];
   
+   compileFilter('mincss', options, results);
    compileFilter('less', options, results);
    compileFilter('stylus', options, results);
    compileFilter('coffee', options, results);
@@ -62,6 +63,30 @@ filters.gzip.check = function(headers, path, type){
   type = headers['content-type'] || type;
   return ((type.match('text') || type.match('javascript')) &&
          acceptEncoding && acceptEncoding.match('gzip'));
+}
+
+//
+// Plain CSS
+//
+filters.mincss = function css(options) {
+  var
+    less = require('less'),
+    lessParser = new less.Parser();
+
+    return function(res, data, cb){
+      lessParser.parse(data, function(err, tree) {
+        if(err){
+          cb(err);
+        }else{
+          res.setHeader("Content-type", "text/css");
+          cb(err, tree.toCSS({compress: true}));
+        }
+      });
+    };
+}
+
+filters.mincss.check = function(headers, path, type) {
+  return (!path.match(/(-|\.)min/)) && (path.match('.css'));
 }
 
 //


### PR DESCRIPTION
Seeing as most already-minified files are usually named something-min.js or something.min.js, I replaced the indexOf('min') check with a regex match against /(-|.)min/
